### PR TITLE
remove the working dir hack, this does not work on EU

### DIFF
--- a/tools/alphafold/alphafold.xml
+++ b/tools/alphafold/alphafold.xml
@@ -55,7 +55,7 @@
         ## html
         mkdir -p '${ html.files_path }' &&
         cp '$__tool_directory__/alphafold.html' ${html} &&
-        cp output/alphafold/ranked_*.pdb '${html.files_path}' &&
+        cp output/alphafold/ranked_*.pdb '${html.files_path}'
 
     ]]></command>
     <inputs>

--- a/tools/alphafold/alphafold.xml
+++ b/tools/alphafold/alphafold.xml
@@ -57,8 +57,6 @@
         cp '$__tool_directory__/alphafold.html' ${html} &&
         cp output/alphafold/ranked_*.pdb '${html.files_path}' &&
 
-        ## For some reason the working directory ends up being one level too deep!
-        mv working/* .
     ]]></command>
     <inputs>
         <conditional name="fasta_or_text">


### PR DESCRIPTION
The hack leads to:

```
mv: cannot stat 'working/*': No such file or directory
```

But the results are available. With this patch everything works for us.